### PR TITLE
Added accessors for raw gyro, accel + STM32F411 sketch

### DIFF
--- a/examples/Stm32F411_SPI_Raw/Stm32F411_SPI_Raw.ino
+++ b/examples/Stm32F411_SPI_Raw/Stm32F411_SPI_Raw.ino
@@ -1,5 +1,4 @@
 #include "ICM20689.h"
-// TODO: Need to test this with the ICM20689
 
 static const uint8_t MOSI_PIN = PA7;
 static const uint8_t MISO_PIN = PA6;
@@ -36,26 +35,25 @@ void setup() {
   // attaching the interrupt to microcontroller pin 1
   pinMode(1,INPUT);
   attachInterrupt(1,getIMU,RISING);
-  Serial.println("ax,ay,az,gx,gy,gz,temp_C");
 }
 
 void loop() {}
 
 void getIMU() {
+
   // read the sensor
   IMU.readSensor();
-  // display the data
-  Serial.print(IMU.getAccelX_mss(),6);
+  
+  // display the raw data
+  Serial.print(IMU.getAccelX_count());
   Serial.print("\t");
-  Serial.print(IMU.getAccelY_mss(),6);
+  Serial.print(IMU.getAccelY_count());
   Serial.print("\t");
-  Serial.print(IMU.getAccelZ_mss(),6);
+  Serial.print(IMU.getAccelZ_count());
   Serial.print("\t");
-  Serial.print(IMU.getGyroX_rads(),6);
+  Serial.print(IMU.getGyroX_count());
   Serial.print("\t");
-  Serial.print(IMU.getGyroY_rads(),6);
+  Serial.print(IMU.getGyroY_count());
   Serial.print("\t");
-  Serial.print(IMU.getGyroZ_rads(),6);
-  Serial.print("\t");
-  Serial.println(IMU.getTemperature_C(),6);
+  Serial.println(IMU.getGyroZ_count());
 }

--- a/examples/Stm32F411_SPI_Raw/Stm32F411_SPI_Raw.ino
+++ b/examples/Stm32F411_SPI_Raw/Stm32F411_SPI_Raw.ino
@@ -1,0 +1,61 @@
+#include "ICM20689.h"
+// TODO: Need to test this with the ICM20689
+
+static const uint8_t MOSI_PIN = PA7;
+static const uint8_t MISO_PIN = PA6;
+static const uint8_t SCLK_PIN = PA5;
+
+static const uint8_t LED_PIN     = PC13;
+static const uint8_t CS_PIN  = PA4;
+static const uint8_t INT_PIN = PA1;
+
+static SPIClass spi = SPIClass(MOSI_PIN, MISO_PIN, SCLK_PIN);
+
+static ICM20689 IMU(spi, CS_PIN);
+
+void setup() {
+  // serial to display data
+  Serial.begin(115200);
+  while(!Serial) {}
+
+  // start communication with IMU
+  auto status = IMU.begin();
+  if (status < 0) {
+    Serial.println("IMU initialization unsuccessful");
+    Serial.println("Check IMU wiring or try cycling power");
+    Serial.print("Status: ");
+    Serial.println(status);
+    while(1) {}
+  }
+  // setting DLPF bandwidth to 20 Hz
+  IMU.setDlpfBandwidth(ICM20689::DLPF_BANDWIDTH_21HZ);
+  // setting SRD to 19 for a 50 Hz update rate
+  IMU.setSrd(19);
+  // enabling the data ready interrupt
+  IMU.enableDataReadyInterrupt();
+  // attaching the interrupt to microcontroller pin 1
+  pinMode(1,INPUT);
+  attachInterrupt(1,getIMU,RISING);
+  Serial.println("ax,ay,az,gx,gy,gz,temp_C");
+}
+
+void loop() {}
+
+void getIMU() {
+  // read the sensor
+  IMU.readSensor();
+  // display the data
+  Serial.print(IMU.getAccelX_mss(),6);
+  Serial.print("\t");
+  Serial.print(IMU.getAccelY_mss(),6);
+  Serial.print("\t");
+  Serial.print(IMU.getAccelZ_mss(),6);
+  Serial.print("\t");
+  Serial.print(IMU.getGyroX_rads(),6);
+  Serial.print("\t");
+  Serial.print(IMU.getGyroY_rads(),6);
+  Serial.print("\t");
+  Serial.print(IMU.getGyroZ_rads(),6);
+  Serial.print("\t");
+  Serial.println(IMU.getTemperature_C(),6);
+}

--- a/src/ICM20689.cpp
+++ b/src/ICM20689.cpp
@@ -446,9 +446,45 @@ double ICM20689::getTemperature_C() {
   return _t;
 }
 
+/* returns the accelerometer measurement in the x direction, raw 16-bit integer */
+int16_t ICM20689::getAccelX_count()
+{
+    return _accCounts[0];
+}
+
+/* returns the accelerometer measurement in the y direction, raw 16-bit integer */
+int16_t ICM20689::getAccelY_count()
+{
+    return _accCounts[1];
+}
+
+/* returns the accelerometer measurement in the z direction, raw 16-bit integer */
+int16_t ICM20689::getAccelZ_count()
+{
+    return _accCounts[2];
+}
+
+/* returns the gyroscople measurement in the x direction, raw 16-bit integer */
+int16_t ICM20689::getGyroX_count()
+{
+    return _gyroCounts[0];
+}
+
+/* returns the gyroscople measurement in the y direction, raw 16-bit integer */
+int16_t ICM20689::getGyroY_count()
+{
+    return _gyroCounts[1];
+}
+
+/* returns the gyroscople measurement in the z direction, raw 16-bit integer */
+int16_t ICM20689::getGyroZ_count()
+{
+    return _gyroCounts[2];
+}
+
 /* configures and enables the FIFO buffer  */
 int ICM20689_FIFO::enableFifo(bool accel,bool gyro,bool temp) {
-  // use low speed SPI for register setting
+    // use low speed SPI for register setting
   _useSPIHS = false;
   if(writeRegister(FIFO_EN,(accel*FIFO_ACCEL)|(gyro*FIFO_GYRO)|(temp*FIFO_TEMP)) < 0) {
     return -2;

--- a/src/ICM20689.h
+++ b/src/ICM20689.h
@@ -58,6 +58,13 @@ class ICM20689{
     double getGyroZ_dps();
     double getTemperature_C();
 
+    int16_t getAccelX_count();
+    int16_t getAccelY_count();
+    int16_t getAccelZ_count();
+    int16_t getGyroX_count();
+    int16_t getGyroY_count();
+    int16_t getGyroZ_count();
+
     int calibrateGyro();
     double getGyroBiasX_rads();
     double getGyroBiasY_rads();


### PR DESCRIPTION
Thanks for this awesome library!  I have an [application](https://github.com/simondlevy/Hackflight) that makes it useful to access the raw sensor values, so I added public accessor methods for those.  As an illustration I also added a simple sketch that runs on an STM32F411-CEU6 flight-control [board](https://www.racedayquads.com/products/happymodel-x12-lite-v1-flight-controller), using the [stm32duino](https://github.com/stm32duino/Arduino_Core_STM32) Arduino core.